### PR TITLE
Improve mobile controls and layout for iPhone screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>テトリス</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/style.css
+++ b/style.css
@@ -281,3 +281,40 @@ body {
   #instructions { display: none; }
   .scoreItem { font-size: 11px; }
 }
+
+/* Improved mobile controls for small screens */
+@media (max-width: 480px) {
+  /* Reserve space for fixed control panel */
+  #gameContainer { padding-bottom: 120px; }
+
+  /* Stick controls to the bottom for easier access */
+  #controls {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    max-width: none;
+    padding: 8px 12px calc(8px + env(safe-area-inset-bottom));
+    background: rgba(34,34,34,0.95);
+  }
+
+  #controlsRow1, #controlsRow2 { gap: 8px; }
+
+  /* Larger tap targets */
+  #controls button {
+    padding: 14px 0;
+    font-size: 16px;
+    min-width: 0;
+  }
+
+  /* Emphasize left/right movement */
+  #leftBtn, #rightBtn {
+    flex: 1.5;
+    font-size: 20px;
+  }
+
+  #downBtn, #rotateBtn {
+    flex: 1;
+    font-size: 18px;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure `viewport-fit=cover` for proper display on iPhone safe areas
- add CSS tweaks that stick control buttons to the bottom and enlarge left/right buttons on small screens

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1b57c2c83308b5f75d3f073b912