### PR TITLE
Use icon buttons for mobile arrow controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,9 +63,9 @@
         
         <div id="controls">
             <div id="controlsRow1">
-                <button id="leftBtn">←</button>
-                <button id="downBtn">↓</button>
-                <button id="rightBtn">→</button>
+                <button id="leftBtn" class="arrow-btn left" aria-label="left"></button>
+                <button id="downBtn" class="arrow-btn down" aria-label="down"></button>
+                <button id="rightBtn" class="arrow-btn right" aria-label="right"></button>
                 <button id="rotateBtn">回転</button>
             </div>
             <div id="controlsRow2">

--- a/script.js
+++ b/script.js
@@ -188,12 +188,19 @@ function handleResize() {
         document.addEventListener('keyup', handleKeyUp);
 
         // モバイルボタン
-        document.getElementById('leftBtn').addEventListener('touchstart', () => simulateKey('ArrowLeft', true));
-        document.getElementById('leftBtn').addEventListener('touchend', () => simulateKey('ArrowLeft', false));
-        document.getElementById('rightBtn').addEventListener('touchstart', () => simulateKey('ArrowRight', true));
-        document.getElementById('rightBtn').addEventListener('touchend', () => simulateKey('ArrowRight', false));
-        document.getElementById('downBtn').addEventListener('touchstart', () => simulateKey('ArrowDown', true));
-        document.getElementById('downBtn').addEventListener('touchend', () => simulateKey('ArrowDown', false));
+        function bindButton(id, key) {
+            const btn = document.getElementById(id);
+            const start = e => { e.preventDefault(); simulateKey(key, true); };
+            const end = e => { e.preventDefault(); simulateKey(key, false); };
+            btn.addEventListener('touchstart', start, { passive: false });
+            btn.addEventListener('touchend', end);
+            btn.addEventListener('mousedown', start);
+            btn.addEventListener('mouseup', end);
+            btn.addEventListener('mouseleave', end);
+        }
+        bindButton('leftBtn', 'ArrowLeft');
+        bindButton('rightBtn', 'ArrowRight');
+        bindButton('downBtn', 'ArrowDown');
         document.getElementById('rotateBtn').addEventListener('click', () => rotatePiece(1));
         document.getElementById('holdBtn').addEventListener('click', holdCurrentPiece);
         document.getElementById('hardDropBtn').addEventListener('click', hardDrop);

--- a/style.css
+++ b/style.css
@@ -154,6 +154,39 @@ body {
     font-size: 20px;
 }
 
+/* arrow buttons without text */
+.arrow-btn {
+    position: relative;
+}
+
+.arrow-btn::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 0;
+    height: 0;
+}
+
+.arrow-btn.left::before {
+    border-style: solid;
+    border-width: 0.5em 0.8em 0.5em 0;
+    border-color: transparent currentColor transparent transparent;
+}
+
+.arrow-btn.right::before {
+    border-style: solid;
+    border-width: 0.5em 0 0.5em 0.8em;
+    border-color: transparent transparent transparent currentColor;
+}
+
+.arrow-btn.down::before {
+    border-style: solid;
+    border-width: 0.8em 0.5em 0 0.5em;
+    border-color: currentColor transparent transparent transparent;
+}
+
 #instructions {
     text-align: center;
     font-size: 12px;


### PR DESCRIPTION
## Summary
- Replace text arrow controls with empty buttons styled as arrows
- Support both touch and mouse events for movement controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b39ccb60833085123ef607a2d81e