### PR TITLE
Enable immediate horizontal movement with mobile buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -230,12 +230,23 @@ window.addEventListener('orientationchange', handleResize);
     function simulateKey(key, pressed) {
         input.keys[key] = pressed;
         if (key === 'ArrowLeft') {
+            if (pressed && !input.leftPressed) {
+                movePiece(-1);
+                input.leftTime = DAS_DELAY;
+            }
             input.leftPressed = pressed;
             if (!pressed) input.leftTime = 0;
         } else if (key === 'ArrowRight') {
+            if (pressed && !input.rightPressed) {
+                movePiece(1);
+                input.rightTime = DAS_DELAY;
+            }
             input.rightPressed = pressed;
             if (!pressed) input.rightTime = 0;
         } else if (key === 'ArrowDown') {
+            if (pressed && !input.downPressed) {
+                input.downTime = ARR_DELAY;
+            }
             input.downPressed = pressed;
             if (!pressed) input.downTime = 0;
         }


### PR DESCRIPTION
## Summary
- trigger immediate piece movement on initial left/right press for mobile controls
- ensure down key press initializes soft drop timing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b25e39af6083308b014546438ff2c2