### PR TITLE
Fix horizontal auto-repeat timing

### DIFF
--- a/script.js
+++ b/script.js
@@ -232,14 +232,14 @@ window.addEventListener('orientationchange', handleResize);
         if (key === 'ArrowLeft') {
             if (pressed && !input.leftPressed) {
                 movePiece(-1);
-                input.leftTime = DAS_DELAY;
+                input.leftTime = 0;
             }
             input.leftPressed = pressed;
             if (!pressed) input.leftTime = 0;
         } else if (key === 'ArrowRight') {
             if (pressed && !input.rightPressed) {
                 movePiece(1);
-                input.rightTime = DAS_DELAY;
+                input.rightTime = 0;
             }
             input.rightPressed = pressed;
             if (!pressed) input.rightTime = 0;
@@ -267,7 +267,7 @@ window.addEventListener('orientationchange', handleResize);
                 if (!input.leftPressed) {
                     movePiece(-1);
                     input.leftPressed = true;
-                    input.leftTime = DAS_DELAY;
+                    input.leftTime = 0;
                 }
                 break;
             case 'ArrowRight':
@@ -275,7 +275,7 @@ window.addEventListener('orientationchange', handleResize);
                 if (!input.rightPressed) {
                     movePiece(1);
                     input.rightPressed = true;
-                    input.rightTime = DAS_DELAY;
+                    input.rightTime = 0;
                 }
                 break;
             case 'ArrowDown':


### PR DESCRIPTION
## Summary
- ensure left/right movement waits for full DAS before auto-repeat

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2890a13d48330a3f0ccef5ed49690